### PR TITLE
Add a type parameter to AttrName.

### DIFF
--- a/src/main/java/jalf/AttrList.java
+++ b/src/main/java/jalf/AttrList.java
@@ -19,11 +19,11 @@ import static java.util.Collections.unmodifiableSortedSet;
  * Instances of this class can be obtained either through factory methods or
  * through JAlf's DSL.
  */
-public class AttrList implements Iterable<AttrName> {
+public class AttrList implements Iterable<AttrName<?>> {
 
-    private SortedSet<AttrName> names;
+    private SortedSet<AttrName<?>> names;
 
-    private AttrList(SortedSet<AttrName> names){
+    private AttrList(SortedSet<AttrName<?>> names){
         this.names = unmodifiableSortedSet(names);
     }
 
@@ -34,8 +34,8 @@ public class AttrList implements Iterable<AttrName> {
      * @param attrNames list of attribute names
      * @return the built attribute list
      */
-    public static AttrList attrs(AttrName... attrNames) {
-        SortedSet<AttrName> set = Stream.of(attrNames)
+    public static AttrList attrs(AttrName<?>... attrNames) {
+        SortedSet<AttrName<?>> set = Stream.of(attrNames)
             .distinct()
             .collect(Collectors.toCollection(TreeSet::new));
         return new AttrList(set);
@@ -49,7 +49,7 @@ public class AttrList implements Iterable<AttrName> {
      * @return the built attribute list
      */
     public static AttrList attrs(String... attrNames) {
-        SortedSet<AttrName> set = Stream.of(attrNames)
+        SortedSet<AttrName<?>> set = Stream.of(attrNames)
             .distinct()
             .map(AttrName::attr)
             .collect(Collectors.toCollection(TreeSet::new));
@@ -57,7 +57,7 @@ public class AttrList implements Iterable<AttrName> {
     }
 
     @Override
-    public Iterator<AttrName> iterator() {
+    public Iterator<AttrName<?>> iterator() {
         return names.iterator();
     }
 

--- a/src/main/java/jalf/AttrName.java
+++ b/src/main/java/jalf/AttrName.java
@@ -12,7 +12,7 @@ import static jalf.util.ValidationUtils.validateNotNull;
  *
  * Instances of this class can be obtained using the `attr` factory method.
  */
-public class AttrName implements Comparable<AttrName> {
+public class AttrName<T> implements Comparable<AttrName<T>> {
 
     private String name;
 
@@ -27,9 +27,14 @@ public class AttrName implements Comparable<AttrName> {
      * @param name of the attribute
      * @return an AttrName instance for `name`
      */
-    public static AttrName attr(String name) {
+    public static AttrName<?> attr(String name) {
         // TODO use a concurrent WeakHashMap to keep immutable AttrName(s)
-        return new AttrName(name);
+        return new AttrName<Object>(name);
+    }
+
+    public static <C> AttrName<C> attr(String name, Class<C> type) {
+        // TODO use a concurrent WeakHashMap to keep immutable AttrName(s)
+        return new AttrName<C>(name);
     }
 
     public String getName() {
@@ -37,7 +42,7 @@ public class AttrName implements Comparable<AttrName> {
     }
 
     @Override
-    public int compareTo(AttrName o) {
+    public int compareTo(AttrName<T> o) {
         return name.compareTo(o.name);
     }
 
@@ -52,7 +57,7 @@ public class AttrName implements Comparable<AttrName> {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        AttrName attrName = (AttrName) o;
+        AttrName<?> attrName = (AttrName<?>) o;
         return name.equals(attrName.name);
     }
 

--- a/src/main/java/jalf/DSL.java
+++ b/src/main/java/jalf/DSL.java
@@ -10,13 +10,17 @@ public class DSL {
 
     // AttrName
 
-    public static AttrName attr(String attr){
+    public static AttrName<?> attr(String attr){
         return AttrName.attr(attr);
+    }
+
+    public static <T> AttrName<T> attr(String attr, Class<T> type){
+        return AttrName.attr(attr, type);
     }
 
     // AttrList
 
-    public static AttrList attrs(AttrName... attrNames) {
+    public static AttrList attrs(AttrName<?>... attrNames) {
         return AttrList.attrs(attrNames);
     }
 
@@ -26,7 +30,7 @@ public class DSL {
 
     // Renaming
 
-    public static Renaming renaming(AttrName... namePairs) {
+    public static Renaming renaming(AttrName<?>... namePairs) {
         return Renaming.extension(namePairs);
     }
 
@@ -68,6 +72,12 @@ public class DSL {
 
     public static Relation restrict(Relation relation, java.util.function.Predicate<Tuple> fn) {
         return restrict(relation, Predicate.java(fn));
+    }
+
+    public static <T> Relation restrict(Relation relation, AttrName<T> name, java.util.function.Predicate<T> fn) {
+        @SuppressWarnings("unchecked")
+        java.util.function.Predicate<Tuple> tfn = (t -> fn.test((T)t.get(name)));
+        return restrict(relation, tfn);
     }
 
 }

--- a/src/main/java/jalf/Renaming.java
+++ b/src/main/java/jalf/Renaming.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
  * by making all pairs explicit) or by intension (i.e. using an arbitrary
  * function). Various static factory methods provide instances of this class.
  */
-public abstract class Renaming implements UnaryOperator<AttrName> {
+public abstract class Renaming implements UnaryOperator<AttrName<?>> {
 
     // DSL information contracts
 
@@ -30,7 +30,7 @@ public abstract class Renaming implements UnaryOperator<AttrName> {
      * @param attrNames before/after mapping of attribute name renaming. 
      * @return a Renaming instance implementing the total function.
      */
-    public static Renaming extension(Map<AttrName, AttrName> attrNames) {
+    public static Renaming extension(Map<AttrName<?>, AttrName<?>> attrNames) {
         validateNotNull("Parameter 'attrNames' must be non-null.", attrNames);
 
         return new Extension(attrNames);
@@ -43,13 +43,13 @@ public abstract class Renaming implements UnaryOperator<AttrName> {
      * @param attrNames a sequence of (before, after) attribute names.
      * @return a Renaming instance implementing the total function.
      */
-    public static Renaming extension(List<AttrName> attrNames) {
+    public static Renaming extension(List<AttrName<?>> attrNames) {
         validateNotNull("Parameter 'attrNames' must be non-null.", attrNames);
 
-        Map<AttrName, AttrName> renamingMap = new HashMap<>();
+        Map<AttrName<?>, AttrName<?>> renamingMap = new HashMap<>();
         for (int i = 0; i < attrNames.size(); i++) {
-            AttrName currentName = attrNames.get(i++);
-            AttrName mappedName = attrNames.get(i);
+            AttrName<?> currentName = attrNames.get(i++);
+            AttrName<?> mappedName = attrNames.get(i);
             renamingMap.put(currentName, mappedName);
         }
         return extension(renamingMap);
@@ -58,10 +58,10 @@ public abstract class Renaming implements UnaryOperator<AttrName> {
     /**
      * Convenient shortcut over `explicit(List<AttrName>)`.
      */
-    public static Renaming extension(AttrName...attrNames) {
+    public static Renaming extension(AttrName<?>... attrNames) {
         validateNotNull("Parameter 'attrNames' must be non-null.", attrNames);
 
-        List<AttrName> attrs = Stream.of(attrNames)
+        List<AttrName<?>> attrs = Stream.of(attrNames)
                 .collect(Collectors.toList());
         return extension(attrs);
     }
@@ -69,10 +69,10 @@ public abstract class Renaming implements UnaryOperator<AttrName> {
     /**
      * Convenient shortcut over `explicit(AttrName[])`.
      */
-    public static Renaming extension(String...attrNames) {
+    public static Renaming extension(String... attrNames) {
         validateNotNull("Parameter 'attrNames' must be non-null.", attrNames);
 
-        List<AttrName> attrs = Stream.of(attrNames)
+        List<AttrName<?>> attrs = Stream.of(attrNames)
                 .map(AttrName::attr)
                 .collect(Collectors.toList());
         return extension(attrs);
@@ -84,7 +84,7 @@ public abstract class Renaming implements UnaryOperator<AttrName> {
      * @param fn a total function from AttrName -> AttrName.
      * @return A decoration of `fn` as a proper Renaming instance.
      */
-    public static Renaming intension(UnaryOperator<AttrName> fn) {
+    public static Renaming intension(UnaryOperator<AttrName<?>> fn) {
         validateNotNull("Parameter 'fn' must be non-null.", fn);
 
         if (fn instanceof Renaming) return (Renaming) fn;
@@ -119,14 +119,14 @@ public abstract class Renaming implements UnaryOperator<AttrName> {
 
     static class Extension extends Renaming {
 
-        private Map<AttrName, AttrName> renamings;
+        private Map<AttrName<?>, AttrName<?>> renamings;
 
-        Extension(Map<AttrName, AttrName> renamings) {
+        Extension(Map<AttrName<?>, AttrName<?>> renamings) {
             this.renamings = unmodifiableMap(renamings);
         }
 
         @Override
-        public AttrName apply(AttrName t) {
+        public AttrName<?> apply(AttrName<?> t) {
             if (renamings.containsKey(t))
                 return renamings.get(t);
             else
@@ -152,14 +152,14 @@ public abstract class Renaming implements UnaryOperator<AttrName> {
 
     static class Intension extends Renaming {
 
-        private UnaryOperator<AttrName> fn;
+        private UnaryOperator<AttrName<?>> fn;
 
-        Intension(UnaryOperator<AttrName> fn) {
+        Intension(UnaryOperator<AttrName<?>> fn) {
             this.fn = fn;
         }
 
         @Override
-        public AttrName apply(AttrName t) {
+        public AttrName<?> apply(AttrName<?> t) {
             return fn.apply(t);
         }
 

--- a/src/main/java/jalf/Tuple.java
+++ b/src/main/java/jalf/Tuple.java
@@ -18,9 +18,9 @@ import static java.util.Collections.unmodifiableMap;
  * through JAlf's DSL. 
  */
 public class Tuple {
-    private Map<AttrName, Object> attrs;
+    private Map<AttrName<?>, Object> attrs;
 
-    private Tuple(Map<AttrName, Object> attrs) {
+    private Tuple(Map<AttrName<?>, Object> attrs) {
         this.attrs = unmodifiableMap(attrs);
     }
 
@@ -36,10 +36,10 @@ public class Tuple {
         validateNotNull("Parameter 'keyValuePairs' must be non-null.", keyValuePairs);
         validate("Length of key-value pairs must be even.", keyValuePairs.length % 2, 0);
 
-        Map<AttrName, Object> attrs = new HashMap<>();
+        Map<AttrName<?>, Object> attrs = new HashMap<>();
         for (int i = 0; i < keyValuePairs.length; i++) {
             Object key = keyValuePairs[i++];
-            AttrName attr = validateCast("Attribute name must be an AttrName.", key, AttrName.class);
+            AttrName<?> attr = validateCast("Attribute name must be an AttrName.", key, AttrName.class);
             Object value = keyValuePairs[i];
             attrs.put(attr, value);
         }
@@ -53,7 +53,7 @@ public class Tuple {
      * @param attrName an attribute name.
      * @return the value associated with the specified attribute name.
      */
-    public Object get(AttrName attrName) {
+    public Object get(AttrName<?> attrName) {
         return attrs.get(attrName);
     }
 
@@ -65,7 +65,7 @@ public class Tuple {
      * @return a projection of this tuple on attributes specified in `on`.
      */
     public Tuple project(AttrList on) {
-        Map<AttrName, Object> p = new HashMap<>();
+        Map<AttrName<?>, Object> p = new HashMap<>();
         on.forEach(attrName -> p.put(attrName, attrs.get(attrName)));
         return new Tuple(p);
     }
@@ -77,10 +77,10 @@ public class Tuple {
      * @return the renamed tuple.
      */
     public Tuple rename(Renaming r) {
-        Map<AttrName, Object> renamed = new HashMap<>();
+        Map<AttrName<?>, Object> renamed = new HashMap<>();
         attrs.entrySet().forEach(attribute -> {
-            AttrName attrName = attribute.getKey();
-            AttrName as = r.apply(attrName);
+            AttrName<?> attrName = attribute.getKey();
+            AttrName<?> as = r.apply(attrName);
             renamed.put(as, attribute.getValue());
         });
         return new Tuple(renamed);
@@ -102,7 +102,7 @@ public class Tuple {
     @Override
     public String toString() {
         String result = "tuple(";
-        for (Map.Entry<AttrName, Object> entry : attrs.entrySet()) {
+        for (Map.Entry<AttrName<?>, Object> entry : attrs.entrySet()) {
             if (result.length() > 6)
                 result += ", ";
             result += '"' + entry.getKey().getName() + '"';

--- a/src/main/java/jalf/predicate/Eq.java
+++ b/src/main/java/jalf/predicate/Eq.java
@@ -25,7 +25,7 @@ public class Eq extends Predicate {
 
     private Object getFor(Object what, Tuple tuple) {
         if (what instanceof AttrName)
-            return tuple.get((AttrName)what);
+            return tuple.get((AttrName<?>)what);
         else
             return what;
     }

--- a/src/test/java/jalf/RenamingTest.java
+++ b/src/test/java/jalf/RenamingTest.java
@@ -7,11 +7,11 @@ import org.junit.Test;
 
 public class RenamingTest {
 
-    AttrName sid = attr("sid");
-    AttrName ssid = attr("ssid");
-    AttrName name = attr("name");
-    AttrName sname = attr("sname");
-    AttrName city = attr("city");
+    AttrName<String> sid = attr("sid", String.class);
+    AttrName<String> ssid = attr("ssid", String.class);
+    AttrName<String> name = attr("name", String.class);
+    AttrName<String> sname = attr("sname", String.class);
+    AttrName<String> city = attr("city", String.class);
 
     @Test
     public void testItSupportsExtensionRenaming() {
@@ -28,7 +28,7 @@ public class RenamingTest {
 
     @Test
     public void testItSupportsIntensionRenaming() {
-        AttrName SID = attr("SID");
+        AttrName<?> SID = attr("SID");
         Renaming r = Renaming.intension(a -> attr(a.toString().toUpperCase()));
         assertEquals(r.apply(sid), SID);
     }

--- a/src/test/java/jalf/test/dsl/RenameTest.java
+++ b/src/test/java/jalf/test/dsl/RenameTest.java
@@ -24,10 +24,10 @@ public class RenameTest {
 
     @Test
     public void testItSupportsPrefixRenaming() {
-        AttrName S_SID = attr("s_sid");
-        AttrName S_NAME = attr("s_name");
-        AttrName S_STATUS = attr("s_status");
-        AttrName S_CITY = attr("s_city");
+        AttrName<String> S_SID = attr("s_sid", String.class);
+        AttrName<String> S_NAME = attr("s_name", String.class);
+        AttrName<Integer> S_STATUS = attr("s_status", Integer.class);
+        AttrName<String> S_CITY = attr("s_city", String.class);
         Relation expected = relation(
             tuple(S_SID, "S1", S_NAME, "Smith", S_STATUS, 20, S_CITY, "London")
         );
@@ -37,10 +37,10 @@ public class RenameTest {
 
     @Test
     public void testItSupportsSuffixRenaming() {
-        AttrName SID_S = attr("sid_s");
-        AttrName NAME_S = attr("name_s");
-        AttrName STATUS_S = attr("status_s");
-        AttrName CITY_S = attr("city_s");
+        AttrName<String> SID_S = attr("sid_s", String.class);
+        AttrName<String> NAME_S = attr("name_s", String.class);
+        AttrName<Integer> STATUS_S = attr("status_s", Integer.class);
+        AttrName<String> CITY_S = attr("city_s", String.class);
         Relation expected = relation(
             tuple(SID_S, "S1", NAME_S, "Smith", STATUS_S, 20, CITY_S, "London")
         );

--- a/src/test/java/jalf/test/dsl/RestrictTest.java
+++ b/src/test/java/jalf/test/dsl/RestrictTest.java
@@ -45,4 +45,16 @@ public class RestrictTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void testItSupportsFriendlyNativePredicates() {
+        Relation expected = relation(
+                tuple(SID, "S3", NAME, "Blake", STATUS, 30, CITY, "Paris"),
+                tuple(SID, "S4", NAME, "Clark", STATUS, 20, CITY, "London"),
+                tuple(SID, "S5", NAME, "Adams", STATUS, 30, CITY, "Athens")
+        );
+        Relation actual = restrict(suppliers(), NAME,
+                (name -> name.indexOf('a') >= 0));
+        assertEquals(expected, actual);
+    }
+
 }

--- a/src/test/java/jalf/test/fixtures/SuppliersAndParts.java
+++ b/src/test/java/jalf/test/fixtures/SuppliersAndParts.java
@@ -7,19 +7,19 @@ import static jalf.DSL.*;
 
 public class SuppliersAndParts {
 
-    public static final AttrName SID = attr("sid");
-    public static final AttrName NAME = attr("name");
-    public static final AttrName CITY = attr("city");
-    public static final AttrName STATUS = attr("status");
+    public static final AttrName<String> SID = attr("sid", String.class);
+    public static final AttrName<String> NAME = attr("name", String.class);
+    public static final AttrName<String> CITY = attr("city", String.class);
+    public static final AttrName<Integer> STATUS = attr("status", Integer.class);
 
-    public static final AttrName PID = attr("pid");
-    public static final AttrName COLOR = attr("color");
-    public static final AttrName WEIGHT = attr("weight");
+    public static final AttrName<String> PID = attr("pid", String.class);
+    public static final AttrName<String> COLOR = attr("color", String.class);
+    public static final AttrName<String> WEIGHT = attr("weight", String.class);
 
-    public static final AttrName QTY = attr("qty");
+    public static final AttrName<Integer> QTY = attr("qty", Integer.class);
 
-    public static final AttrName SUPPLIER_ID = attr("supplier_id");
-    public static final AttrName LIVES_IN = attr("lives_in");
+    public static final AttrName<String> SUPPLIER_ID = attr("supplier_id", String.class);
+    public static final AttrName<String> LIVES_IN = attr("lives_in", String.class);
 
     public static Relation suppliers() {
         return relation(


### PR DESCRIPTION
This pull request adds a type parameter, yielding `AttrName<T>`. As shown in the test, the original motivation is to provide friendly shortuts on restrict (other operators might benefit from it too), such as:

``` java
restrict(suppliers(), NAME, (name -> name.indexOf('a') > 0))
```

In the example above, `NAME` is defined as `Attr<String>`, which allows that `String` parameter to be captured and passed to a String-based predicate, which is nice to use and see.

However, it obviously leads to such a generics nightmare so that I'm not sure it's worth it. @etcinitd WDYT? Any experience with those genetics stuff. Mine is old and was pretty bad...
