### PR TITLE
Add TypedAttrName<T> for better DSL.

### DIFF
--- a/src/main/java/jalf/AttrName.java
+++ b/src/main/java/jalf/AttrName.java
@@ -16,7 +16,7 @@ public class AttrName implements Comparable<AttrName> {
 
     private String name;
 
-    private AttrName(String name) {
+    AttrName(String name) {
         validateNotNull("Parameter 'name' must be non-null.", name);
         this.name = name;
     }
@@ -61,4 +61,11 @@ public class AttrName implements Comparable<AttrName> {
         return "attr(\"" + name + "\"";
     }
 
+    public TypedAttrName<String> asStr() {
+        return new TypedAttrName<>(this, String.class);
+    }
+
+    public <T> TypedAttrName<T> as(Class<T> type) {
+        return new TypedAttrName<>(this, type);
+    }
 }

--- a/src/main/java/jalf/DSL.java
+++ b/src/main/java/jalf/DSL.java
@@ -10,7 +10,7 @@ public class DSL {
 
     // AttrName
 
-    public static AttrName attr(String attr){
+    public static AttrName attr(String attr) {
         return AttrName.attr(attr);
     }
 
@@ -70,4 +70,9 @@ public class DSL {
         return restrict(relation, Predicate.java(fn));
     }
 
+    public static <T> Relation restrict(Relation relation, TypedAttrName<T> name, java.util.function.Predicate<T> fn) {
+        @SuppressWarnings("unchecked")
+        java.util.function.Predicate<Tuple> tfn = (t -> fn.test((T) t.get(name)));
+        return restrict(relation, tfn);
+    }
 }

--- a/src/main/java/jalf/TypedAttrName.java
+++ b/src/main/java/jalf/TypedAttrName.java
@@ -1,0 +1,48 @@
+package jalf;
+
+/**
+ */
+class TypedAttrName<T> extends AttrName {
+    private AttrName delegate;
+    private Class<T> type;
+
+    TypedAttrName(AttrName attrName, Class<T> type) {
+        super(attrName.getName());
+        delegate = attrName;
+        this.type = type;
+    }
+
+    public Class<T> getType() {
+        return type;
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public TypedAttrName<String> asStr() {
+        return delegate.asStr();
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public int compareTo(AttrName o) {
+        return delegate.compareTo(o);
+    }
+}

--- a/src/test/java/jalf/test/dsl/RestrictTest.java
+++ b/src/test/java/jalf/test/dsl/RestrictTest.java
@@ -41,8 +41,30 @@ public class RestrictTest {
                 tuple(SID, "S5", NAME, "Adams", STATUS, 30, CITY, "Athens")
         );
         Relation actual = restrict(suppliers(),
-                (t -> ((String)t.get(NAME)).indexOf('a') >= 0));
+                t -> ((String)t.get(NAME)).indexOf('a') >= 0);
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void testItSupportsFriendlyNativePredicates() {
+        Relation expected = relation(
+                tuple(SID, "S3", NAME, "Blake", STATUS, 30, CITY, "Paris"),
+                tuple(SID, "S4", NAME, "Clark", STATUS, 20, CITY, "London"),
+                tuple(SID, "S5", NAME, "Adams", STATUS, 30, CITY, "Athens")
+        );
+        Relation actual = restrict(suppliers(), NAME.asStr(),
+                name -> name.indexOf('a') >= 0);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testItSupportsTypeCastedFriendlyNativePredicates() {
+        Relation expected = relation(
+                tuple(SID, "S3", NAME, "Blake", STATUS, 30, CITY, "Paris"),
+                tuple(SID, "S5", NAME, "Adams", STATUS, 30, CITY, "Athens")
+        );
+        Relation actual = restrict(suppliers(), STATUS.as(Integer.class),
+                status -> status == 30);
+        assertEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
What about doing it this way?

`restrict(suppliers(), NAME.asStr(), name -> name.contains('a'));`
`restrict(suppliers(), STATUS.as(Integer.class), status -> status == 30);`

I really don't want us to make AttrName a generic at this stage. It just propagates everywhere.
